### PR TITLE
Fix Metadata Storage for @Attribute

### DIFF
--- a/src/constants/symbols.ts
+++ b/src/constants/symbols.ts
@@ -1,0 +1,1 @@
+export const AttributeMetadata = Symbol('AttributeMetadata');

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,8 @@ export * from './models/links.model';
 export * from './models/link.model';
 export * from './models/error-response.model';
 
+export * from './constants/symbols';
+
 export * from './providers';
 
 export * from './module';

--- a/src/models/json-api.model.ts
+++ b/src/models/json-api.model.ts
@@ -5,6 +5,7 @@ import { JsonApiDatastore, ModelType } from '../services/json-api-datastore.serv
 import { LinksModel } from './links.model';
 import { LinkModel } from './link.model';
 import { DocumentModel } from '../models/document.model';
+import { AttributeMetadata } from '../constants/symbols';
 
 export class JsonApiModel {
 
@@ -32,12 +33,12 @@ export class JsonApiModel {
   }
 
   save(params?: any, headers?: Headers): Observable<DocumentModel<this>> {
-    let attributesMetadata: any = Reflect.getMetadata('Attribute', this);
+    let attributesMetadata: any = this[AttributeMetadata];
     return this._datastore.saveRecord(attributesMetadata, this, params, headers);
   }
 
   get hasDirtyAttributes() {
-    let attributesMetadata: any = Reflect.getMetadata('Attribute', this);
+    let attributesMetadata: any = this[AttributeMetadata];
     let hasDirtyAttributes = false;
     for (let propertyName in attributesMetadata) {
       if (attributesMetadata.hasOwnProperty(propertyName)) {
@@ -52,7 +53,7 @@ export class JsonApiModel {
   }
 
   rollbackAttributes(): void {
-    let attributesMetadata: any = Reflect.getMetadata('Attribute', this);
+    let attributesMetadata: any = this[AttributeMetadata];
     let metadata: any;
     for (let propertyName in attributesMetadata) {
       if (attributesMetadata.hasOwnProperty(propertyName)) {
@@ -67,7 +68,8 @@ export class JsonApiModel {
         }
       }
     }
-    Reflect.defineMetadata('Attribute', attributesMetadata, this);
+
+    this[AttributeMetadata] = attributesMetadata;
   }
 
   private parseHasMany(data: any, included: any, level: number): void {

--- a/src/services/json-api-datastore.service.ts
+++ b/src/services/json-api-datastore.service.ts
@@ -9,6 +9,7 @@ import 'rxjs/add/observable/throw';
 import { JsonApiModel } from '../models/json-api.model';
 import { DocumentModel } from '../models/document.model';
 import {ErrorResponse} from '../models/error-response.model';
+import { AttributeMetadata } from '../constants/symbols';
 
 export type ModelType<T extends JsonApiModel> = {
   new(
@@ -248,7 +249,7 @@ export class JsonApiDatastore {
   }
 
   private resetMetadataAttributes<T extends JsonApiModel>(res: any, attributesMetadata: any, modelType: ModelType<T>) {
-    attributesMetadata = Reflect.getMetadata('Attribute', res);
+    attributesMetadata = res[AttributeMetadata];
     for (let propertyName in attributesMetadata) {
       if (attributesMetadata.hasOwnProperty(propertyName)) {
         let metadata: any = attributesMetadata[propertyName];
@@ -257,7 +258,8 @@ export class JsonApiDatastore {
         }
       }
     }
-    Reflect.defineMetadata('Attribute', attributesMetadata, res);
+
+    res[AttributeMetadata] = attributesMetadata;
     return res;
   }
 


### PR DESCRIPTION
Attribute metadata was saved directly on the decorator using the Reflection API. This means that metadata was static and shared across model instances. To fix this, two changes were performed:

1. `@Attribute` is now just a marker interface. It registers a property just so it can be enumerated across.
2. The data is now saved directly on instances, using a Symbol.

Fixes bugs where multiple models of the same type would share internal data (manifested on save/update).